### PR TITLE
MM-25396: emit RECEIVED_WEBAPP_PLUGIN

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -4,6 +4,11 @@ export default class Plugin {
     // eslint-disable-next-line no-unused-vars
     initialize(registry, store) {
         // @see https://developers.mattermost.com/extend/plugins/webapp/reference/
+
+        // The webapp fails to emit an ActionTypes.RECEIVED_WEBAPP_PLUGIN when the plugin is
+        // activated after the page has already loaded. Emit one ourselves to simplify integration
+        // while we wait for the webapp to be fixed.
+        store.dispatch({type: 'RECEIVED_WEBAPP_PLUGIN', data: manifest});
     }
 }
 


### PR DESCRIPTION
#### Summary
As part of https://mattermost.atlassian.net/browse/MM-17087, the webapp no longer emits `RECEIVED_WEBAPP_PLUGIN`. This makes it impossible to use the Redux store alone to detect the presence of plugins installed /after/ a page load. (The webapp still tracks all such plugins via `RECEIVED_WEBAPP_PLUGINS` on page load.)

Emit the event ourselves to better interop with the incident response plugin while we wait for the webapp to fix this.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-25396