### PR TITLE
Disable cgo and fix misaligned structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,19 +63,19 @@ server:
 ifneq ($(HAS_SERVER),)
 	mkdir -p server/dist;
 ifeq ($(MM_DEBUG),)
-	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-linux-amd64;
-	cd server && env GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-linux-arm64;
-	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-darwin-amd64;
-	cd server && env GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-darwin-arm64;
-	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-windows-amd64.exe;
+	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-linux-amd64;
+	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-linux-arm64;
+	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-darwin-amd64;
+	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-darwin-arm64;
+	cd server && env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -trimpath -o dist/plugin-windows-amd64.exe;
 else
 	$(info DEBUG mode is on; to disable, unset MM_DEBUG)
 
-	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-darwin-amd64;
-	cd server && env GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-darwin-arm64;
-	cd server && env GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-linux-arm64;
-	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-linux-amd64;
-	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-windows-amd64.exe;
+	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-linux-amd64;
+	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-linux-arm64;
+	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-darwin-amd64;
+	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-darwin-arm64;
+	cd server && env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -trimpath -o dist/plugin-windows-amd64.exe;
 endif
 endif
 

--- a/server/api.go
+++ b/server/api.go
@@ -32,9 +32,9 @@ func registerAPI(router *mux.Router, client *pluginapi.Wrapper, makePostsIterato
 
 // APIError is a type of error returned by the API.
 type APIError struct {
-	StatusCode int
 	StatusText string
 	Message    string
+	StatusCode int
 }
 
 func (e *APIError) Error() string {

--- a/server/client.go
+++ b/server/client.go
@@ -17,10 +17,10 @@ const FormatCSV = "csv"
 
 // Client is the programmatic interface to the channel export plugin.
 type Client struct {
+	httpClient *http.Client
 	Address    string
 	AuthToken  string
 	AuthType   string
-	httpClient *http.Client
 }
 
 // NewClient creates a client to the channel export plugin at the given address.
@@ -32,6 +32,7 @@ func NewClient(address string) *Client {
 }
 
 // NewMattermostServerClient creates a client to the channel export plugin at the given Mattermost server address.
+//
 //nolint:deadcode,unused
 func NewMattermostServerClient(mattermostServerAddress string) *Client {
 	if !strings.HasSuffix(mattermostServerAddress, "/") {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -20,21 +20,22 @@ type Plugin struct {
 	plugin.MattermostPlugin
 	clientPluginAPI *pluginapi.Client
 
-	// configurationLock synchronizes access to the configuration.
-	configurationLock sync.RWMutex
-
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
 	configuration *configuration
 
 	client *pluginAPIWrapper.Wrapper
-	botID  string
 
 	// router is the plugin's root HTTP handler
 	router *mux.Router
 
 	// makeChannelPostsIterator is a factory function for iterating over posts
 	makeChannelPostsIterator func(*model.Channel, bool) PostIterator
+
+	botID string
+
+	// configurationLock synchronizes access to the configuration.
+	configurationLock sync.RWMutex
 }
 
 const (


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Disabled cgo to improve the reliability of builds.

Fixed go fmt issue on a comment in client.go
```
server/client.go:34: File is not `gofmt`-ed with `-s` (gofmt)
// NewMattermostServerClient creates a client to the channel export plugin at the given Mattermost server address.
```

Fixed fieldalignment errors on the govet linter by reordering the fields in the structures.

```
server/api.go:34:15: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type APIError struct {
              ^
server/client.go:19:13: fieldalignment: struct with 56 pointer bytes could be 48 (govet)
type Client struct {
            ^
server/plugin.go:19:13: fieldalignment: struct with 112 pointer bytes could be 80 (govet)
type Plugin struct {
```


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-plugin-starter-template/pull/167
https://mattermost.atlassian.net/browse/MM-43713