### PR TITLE
Adds support for restricting channel export to administrator

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -22,6 +22,14 @@
     "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [
+            {
+                "key": "EnableAdminRestrictions",
+                "display_name": "Enable Admin Restrictions",
+                "type": "bool",
+                "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
+                "default": "false"
+            }
+        ]
     }
 }

--- a/server/api.go
+++ b/server/api.go
@@ -143,7 +143,7 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.plugin.hasPermissionToExportChannel(userID) {
+	if !h.plugin.hasPermissionToExportChannel(userID, channelID) {
 		handleError(w, http.StatusForbidden, "user does not have permission", channelID)
 		return
 	}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -22,9 +22,13 @@ import (
 )
 
 func setupAPI(t *testing.T, mockAPI *pluginapi.Wrapper, now time.Time, userID, _ /*channelID*/ string) string {
-	p := Plugin{}
 	router := mux.NewRouter()
-	err := p.registerAPI(router, mockAPI, makeTestPostsIterator(t, now))
+	p := Plugin{
+		router: router,
+		client: mockAPI,
+	}
+
+	err := registerAPI(&p, makeTestPostsIterator(t, now))
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -22,8 +22,9 @@ import (
 )
 
 func setupAPI(t *testing.T, mockAPI *pluginapi.Wrapper, now time.Time, userID, _ /*channelID*/ string) string {
+	p := Plugin{}
 	router := mux.NewRouter()
-	err := registerAPI(router, mockAPI, makeTestPostsIterator(t, now))
+	err := p.registerAPI(router, mockAPI, makeTestPostsIterator(t, now))
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -70,7 +70,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		}
 	}
 
-	if !p.hasPermissionToExportChannel(args.UserId) {
+	if !p.hasPermissionToExportChannel(args.UserId, args.ChannelId) {
 		return &model.CommandResponse{
 			ResponseType: model.CommandResponseTypeEphemeral,
 			Text:         "You do not have enough permissions to export this channel",
@@ -193,10 +193,10 @@ func (p *Plugin) uploadFileTo(fileName string, contents io.Reader, channelID str
 	return file, nil
 }
 
-func (p *Plugin) hasPermissionToExportChannel(userID string) bool {
+func (p *Plugin) hasPermissionToExportChannel(userID, channelID string) bool {
 	conf := p.getConfiguration()
 	if conf.EnableAdminRestrictions {
-		if !(p.client.User.HasPermissionTo(userID, model.PermissionManageChannelRoles) || p.client.User.HasPermissionTo(userID, model.PermissionManageSystem)) {
+		if !(p.client.User.HasPermissionToChannel(userID, channelID, model.PermissionManageChannelRoles) || p.client.User.HasPermissionTo(userID, model.PermissionManageSystem)) {
 			return false
 		}
 	}

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -70,13 +70,10 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		}
 	}
 
-	conf := p.getConfiguration()
-	if conf.EnableAdminRestrictions {
-		if !(p.client.User.HasPermissionTo(args.UserId, model.PermissionManageChannelRoles) || p.client.User.HasPermissionTo(args.UserId, model.PermissionManageSystem)) {
-			return &model.CommandResponse{
-				ResponseType: model.CommandResponseTypeEphemeral,
-				Text:         "You do not have enough permissions to export this channel",
-			}
+	if !p.hasPermissionToExportChannel(args.UserId) {
+		return &model.CommandResponse{
+			ResponseType: model.CommandResponseTypeEphemeral,
+			Text:         "You do not have enough permissions to export this channel",
 		}
 	}
 
@@ -194,4 +191,14 @@ func (p *Plugin) uploadFileTo(fileName string, contents io.Reader, channelID str
 	}
 
 	return file, nil
+}
+
+func (p *Plugin) hasPermissionToExportChannel(userID string) bool {
+	conf := p.getConfiguration()
+	if conf.EnableAdminRestrictions {
+		if !(p.client.User.HasPermissionTo(userID, model.PermissionManageChannelRoles) || p.client.User.HasPermissionTo(userID, model.PermissionManageSystem)) {
+			return false
+		}
+	}
+	return true
 }

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -70,6 +70,16 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		}
 	}
 
+	conf := p.getConfiguration()
+	if conf.EnableAdminRestrictions {
+		if !(p.client.User.HasPermissionTo(args.UserId, model.PermissionManageChannelRoles) || p.client.User.HasPermissionTo(args.UserId, model.PermissionManageSystem)) {
+			return &model.CommandResponse{
+				ResponseType: model.CommandResponseTypeEphemeral,
+				Text:         "You do not have enough permissions to export this channel",
+			}
+		}
+	}
+
 	channelToExport, err := p.client.Channel.Get(args.ChannelId)
 	if err != nil {
 		p.client.Log.Error("unable to retrieve the channel to export",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -18,6 +18,7 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
+	EnableAdminRestrictions bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -36,7 +36,16 @@ const manifestStr = `
   "settings_schema": {
     "header": "",
     "footer": "",
-    "settings": []
+    "settings": [
+      {
+        "key": "EnableAdminRestrictions",
+        "display_name": "Enable Admin Restrictions",
+        "type": "bool",
+        "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
+        "placeholder": "",
+        "default": "false"
+      }
+    ]
   }
 }
 `

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -40,6 +40,9 @@ type Plugin struct {
 
 	// clusterMutex is used to ensure only one export can be done at a time across the cluster
 	clusterMutex pluginAPIWrapper.ClusterMutex
+
+	// handler is here to ensure the api is able to check configuration
+	handler Handler
 }
 
 const (
@@ -81,7 +84,9 @@ func (p *Plugin) OnActivate() error {
 	p.makeChannelPostsIterator = func(channel *model.Channel, showEmailAddress bool) PostIterator {
 		return channelPostsIterator(p.client, channel, showEmailAddress)
 	}
-	return registerAPI(p.router, p.client, p.makeChannelPostsIterator)
+	p.handler = Handler{}
+
+	return p.registerAPI(p.router, p.client, p.makeChannelPostsIterator)
 }
 
 // ServeHTTP handles requests to /plugins/com.mattermost.plugin-incident-response

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -40,9 +40,6 @@ type Plugin struct {
 
 	// clusterMutex is used to ensure only one export can be done at a time across the cluster
 	clusterMutex pluginAPIWrapper.ClusterMutex
-
-	// handler is here to ensure the api is able to check configuration
-	handler Handler
 }
 
 const (
@@ -84,9 +81,8 @@ func (p *Plugin) OnActivate() error {
 	p.makeChannelPostsIterator = func(channel *model.Channel, showEmailAddress bool) PostIterator {
 		return channelPostsIterator(p.client, channel, showEmailAddress)
 	}
-	p.handler = Handler{}
 
-	return p.registerAPI(p.router, p.client, p.makeChannelPostsIterator)
+	return registerAPI(p, p.makeChannelPostsIterator)
 }
 
 // ServeHTTP handles requests to /plugins/com.mattermost.plugin-incident-response

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -26,7 +26,16 @@ const manifest = JSON.parse(`
     "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [
+            {
+                "key": "EnableAdminRestrictions",
+                "display_name": "Enable Admin Restrictions",
+                "type": "bool",
+                "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
+                "placeholder": "",
+                "default": "false"
+            }
+        ]
     }
 }
 `);


### PR DESCRIPTION
This PR is part of my Sim project for Mattermost and adds the ability to restrict the `/export` command or api export request to the mattermost system administrators and channel admins.  

You are able to enable/disable the admin user check from the plugin settings in the UI (defaults to disabled). 
