### PR TITLE
[MM-46]: Updated the message for exporting channels

### DIFF
--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -95,16 +95,27 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		exportSuccessMsg = fmt.Sprintf("Channel ~%s exported:", channelToExportName)
 		exportProcessMsg = fmt.Sprintf("Exporting ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
 	case model.ChannelTypeGroup:
-		channelToExportName = channelToExport.Name
+		channelToExportNameID := channelToExport.Name
+		groupChannelMembers := strings.Split(channelToExport.DisplayName, ", ")
+		membersCount := len(groupChannelMembers)
+
+		for i := 0; i < 2 && i < membersCount; i++ {
+			channelToExportName += groupChannelMembers[i] + ", "
+		}
+
+		if membersCount > 2 {
+			channelToExportName += fmt.Sprintf("and %d more", (membersCount - 2))
+		}
+
 		team, appErr := p.API.GetTeam(args.TeamId)
 		if appErr != nil {
 			p.client.Log.Error("error occurred while getting the details of team for the channel.", "GMChannelID", args.ChannelId, "TeamID", args.TeamId, "Error", appErr)
 
-			exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
+			exportProcessMsg = fmt.Sprintf("Exporting GM channel ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
 			exportSuccessMsg = fmt.Sprintf("GM Channel ~%s exported:", channelToExportName)
 		} else {
-			link := fmt.Sprintf("%s/%s/messages/%s", args.SiteURL, team.Name, channelToExportName)
-			exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~[%s](%s). @%s will send you a direct message when the export is ready.", channelToExportName, link, botUsername)
+			link := fmt.Sprintf("%s/%s/messages/%s", args.SiteURL, team.Name, channelToExportNameID)
+			exportProcessMsg = fmt.Sprintf("Exporting GM channel ~[%s](%s). @%s will send you a direct message when the export is ready.", channelToExportName, link, botUsername)
 			exportSuccessMsg = fmt.Sprintf("GM Channel ~[%s](%s) exported:", channelToExportName, link)
 		}
 	case model.ChannelTypeDirect:

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -96,9 +96,9 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		exportProcessMsg = fmt.Sprintf("Exporting ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
 	case model.ChannelTypeGroup:
 		channelToExportName = channelToExport.Name
-		team, err := p.API.GetTeam(args.TeamId)
-		if err != nil {
-			p.client.Log.Error("error occurred while getting the details of team for the channel.", "GMChannelID", args.ChannelId, "TeamID", args.TeamId, "Error", err)
+		team, appErr := p.API.GetTeam(args.TeamId)
+		if appErr != nil {
+			p.client.Log.Error("error occurred while getting the details of team for the channel.", "GMChannelID", args.ChannelId, "TeamID", args.TeamId, "Error", appErr)
 
 			exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
 			exportSuccessMsg = fmt.Sprintf("GM Channel ~%s exported:", channelToExportName)
@@ -116,7 +116,8 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 			DMUserID = userIDs[0]
 		}
 
-		user, err := p.client.User.Get(DMUserID)
+		var user *model.User
+		user, err = p.client.User.Get(DMUserID)
 		if err != nil {
 			p.client.Log.Error("error occurred while getting the details of user for the DM.", "DMChannelID", args.ChannelId, "TeamID", args.TeamId, "Error", err)
 

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -92,10 +92,9 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 	if channelToExport.Type == model.ChannelTypeOpen || channelToExport.Type == model.ChannelTypePrivate {
 		channelToExportName = channelToExport.Name
 		exportSuccessMsg = fmt.Sprintf("Channel ~%s exported:", channelToExportName)
-		exportProcessMsg = "Exporting ~%s. @%s will send you a direct message when the export is ready."
+		exportProcessMsg = fmt.Sprintf("Exporting ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
 	} else if channelToExport.Type == model.ChannelTypeGroup {
 		channelToExportName = channelToExport.Name
-		exportProcessMsg = "Exporting this GM channel ~%s. @%s will send you a direct message when the export is ready."
 		team, err := p.API.GetTeam(args.TeamId)
 		if err != nil {
 			p.client.Log.Error("error occurred while getting the details of team for the channel.",
@@ -107,6 +106,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 			}
 		}
 		link := fmt.Sprintf("%s/%s/messages/%s", args.SiteURL, team.Name, channelToExportName)
+		exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~[%s](%s). @%s will send you a direct message when the export is ready.", channelToExportName, link, botUsername)
 		exportSuccessMsg = fmt.Sprintf("GM Channel ~[%s](%s) exported:", channelToExportName, link)
 
 	} else if channelToExport.Type == model.ChannelTypeDirect {
@@ -114,7 +114,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		user, _ := p.client.User.Get(DMUserName)
 		channelToExportName = user.Username
 		exportSuccessMsg = fmt.Sprintf("DM with @%s exported:", channelToExportName)
-		exportProcessMsg = "Exporting DM with @%s. @%s will send you a direct message when the export is ready."
+		exportProcessMsg = fmt.Sprintf("Exporting DM with @%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
 	}
 
 	channelDM, err := p.client.Channel.GetDirect(args.UserId, p.botID)
@@ -206,7 +206,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 
 	return &model.CommandResponse{
 		ResponseType: model.CommandResponseTypeEphemeral,
-		Text:         fmt.Sprintf(exportProcessMsg, channelToExportName, botUsername),
+		Text:         exportProcessMsg,
 	}
 }
 

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -97,18 +97,15 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 		channelToExportName = channelToExport.Name
 		team, err := p.API.GetTeam(args.TeamId)
 		if err != nil {
-			p.client.Log.Error("error occurred while getting the details of team for the channel.",
-				"GM channel ID", args.ChannelId, "User ID", args.UserId, "Error", err)
+			p.client.Log.Error("error occurred while getting the details of team for the channel.", "GMChannelID", args.ChannelId, "TeamID", args.TeamId, "Error", err)
 
-			return &model.CommandResponse{
-				ResponseType: model.CommandResponseTypeEphemeral,
-				Text:         fmt.Sprintf("An error occurred trying to exporting the chat for %s GM channel", channelToExportName),
-			}
+			exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~%s. @%s will send you a direct message when the export is ready.", channelToExportName, botUsername)
+			exportSuccessMsg = fmt.Sprintf("GM Channel ~%s exported:", channelToExportName)
+		} else {
+			link := fmt.Sprintf("%s/%s/messages/%s", args.SiteURL, team.Name, channelToExportName)
+			exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~[%s](%s). @%s will send you a direct message when the export is ready.", channelToExportName, link, botUsername)
+			exportSuccessMsg = fmt.Sprintf("GM Channel ~[%s](%s) exported:", channelToExportName, link)
 		}
-		link := fmt.Sprintf("%s/%s/messages/%s", args.SiteURL, team.Name, channelToExportName)
-		exportProcessMsg = fmt.Sprintf("Exporting this GM channel ~[%s](%s). @%s will send you a direct message when the export is ready.", channelToExportName, link, botUsername)
-		exportSuccessMsg = fmt.Sprintf("GM Channel ~[%s](%s) exported:", channelToExportName, link)
-
 	} else if channelToExport.Type == model.ChannelTypeDirect {
 		DMUserName := strings.Split(channelToExport.Name, "__")[0]
 		user, _ := p.client.User.Get(DMUserName)

--- a/server/command_hooks_test.go
+++ b/server/command_hooks_test.go
@@ -121,7 +121,7 @@ func TestExecuteCommand(t *testing.T) {
 				EnableDeveloper: &trueValue,
 			},
 		}).Times(1)
-		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name"}, nil)
+		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name", Type: model.ChannelTypeOpen}, nil)
 		mockChannel.EXPECT().GetDirect("user_id", "bot_id").Return(&model.Channel{Id: "direct"}, nil)
 		mockUser.EXPECT().HasPermissionTo("user_id", model.PermissionManageSystem).Return(false).Times(1)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{
@@ -217,7 +217,7 @@ func TestExecuteCommand(t *testing.T) {
 			FutureFeatures: &trueValue,
 		}}).Times(2)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
-		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id"}, nil)
+		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Type: model.ChannelTypeOpen}, nil)
 		mockChannel.EXPECT().GetDirect("user_id", "bot_id").Return(nil, errors.New("failed"))
 		mockLog.EXPECT().Error("unable to create a direct message channel between the bot and the user", "Bot ID", "bot_id", "User ID", "user_id", "Error", gomock.Any())
 
@@ -255,7 +255,7 @@ func TestExecuteCommand(t *testing.T) {
 			FutureFeatures: &trueValue,
 		}}).Times(2)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
-		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name"}, nil)
+		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name", Type: model.ChannelTypeOpen}, nil)
 		mockChannel.EXPECT().GetDirect("user_id", "bot_id").Return(&model.Channel{Id: "direct"}, nil)
 		mockUser.EXPECT().HasPermissionTo("user_id", model.PermissionManageSystem).Return(false).Times(1)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
@@ -313,7 +313,7 @@ func TestExecuteCommand(t *testing.T) {
 			FutureFeatures: &trueValue,
 		}}).Times(2)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
-		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name"}, nil)
+		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name", Type: model.ChannelTypeOpen}, nil)
 		mockChannel.EXPECT().GetDirect("user_id", "bot_id").Return(&model.Channel{Id: "direct"}, nil)
 		mockUser.EXPECT().HasPermissionTo("user_id", model.PermissionManageSystem).Return(false).Times(1)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{
@@ -375,7 +375,7 @@ func TestExecuteCommand(t *testing.T) {
 			FutureFeatures: &trueValue,
 		}}).Times(2)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
-		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name"}, nil)
+		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name", Type: model.ChannelTypeOpen}, nil)
 		mockChannel.EXPECT().GetDirect("user_id", "bot_id").Return(&model.Channel{Id: "direct"}, nil)
 		mockUser.EXPECT().HasPermissionTo("user_id", model.PermissionManageSystem).Return(false).Times(1)
 		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{


### PR DESCRIPTION
#### Summary
- Updated the messages received while exporting different types of channels.
- Fixed the issue of missing links to the DM/GM conversation in the response received from the Channel export bot with the attachments

#### Ticket link
 Fixes https://github.com/mattermost/mattermost-plugin-channel-export/issues/46
 
### Testing steps
- Start a conversation with channel, single and multiple users as a direct message in Mattermost.
- Run the `/export` slash command.
- Check the response by the Channel Export bot.
 
### Screenshots
#### Existing
![Screenshot from 2024-08-14 09-19-55](https://github.com/user-attachments/assets/8a6485e0-7102-49d3-8667-cb6abc26524e)
![Screenshot from 2024-08-14 09-05-19](https://github.com/user-attachments/assets/d43555a6-fd68-48ce-b0d2-7aae2e42209e)
![Screenshot from 2024-08-21 14-16-56](https://github.com/user-attachments/assets/be9e99a4-730e-47ec-a16f-9de655ff2d7f)
![Screenshot from 2024-08-21 14-17-40](https://github.com/user-attachments/assets/2aab5978-dffe-421b-8429-8f7f8bf6365c)


#### Updated
![Screenshot from 2024-08-14 09-06-30](https://github.com/user-attachments/assets/97ce7845-f390-454a-ae17-17108755e297)
![Screenshot from 2024-08-21 14-16-20](https://github.com/user-attachments/assets/0ceae8aa-a12f-4ca3-87ab-2b3b39bbb6a8)
![Screenshot from 2024-08-21 16-30-46](https://github.com/user-attachments/assets/f8aacb1e-f238-41cb-a07b-cdf58cd621b9)
![Screenshot from 2024-08-14 09-05-51](https://github.com/user-attachments/assets/661d92e0-c7cc-42fa-9c0d-19b36dd93c27)