### PR TITLE
Permission and error messages improvements

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,7 +28,7 @@
                 "display_name": "Enable Admin Restrictions",
                 "type": "bool",
                 "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
-                "default": "false"
+                "default": false
             }
         ]
     }

--- a/server/api.go
+++ b/server/api.go
@@ -116,7 +116,7 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 
 	license := h.client.System.GetLicense()
 	if !isLicensed(license, h.client) {
-		handleError(w, http.StatusBadRequest, "the channel export plugin requires a valid E20 license.")
+		handleError(w, http.StatusBadRequest, "the channel export plugin requires a valid Enterprise license.")
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !h.plugin.hasPermissionToExportChannel(userID, channelID) {
-		handleError(w, http.StatusForbidden, "user does not have permission", channelID)
+		handleError(w, http.StatusForbidden, "user does not have permission to export channels")
 		return
 	}
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -102,7 +102,7 @@ func TestHandler(t *testing.T) {
 		}).Times(1)
 
 		err := client.ExportChannel(io.Discard, "channel_id", FormatCSV)
-		require.EqualError(t, err, "the channel export plugin requires a valid E20 license.")
+		require.EqualError(t, err, "the channel export plugin requires a valid Enterprise license.")
 	})
 
 	t.Run("missing e20 license with Testing and Developer modes enabled", func(t *testing.T) {

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -66,7 +66,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 	if !isLicensed(license, p.client) {
 		return &model.CommandResponse{
 			ResponseType: model.CommandResponseTypeEphemeral,
-			Text:         "The channel export plugin requires a valid E20 license.",
+			Text:         "The channel export plugin requires a valid Enterprise license.",
 		}
 	}
 

--- a/server/command_hooks_test.go
+++ b/server/command_hooks_test.go
@@ -92,7 +92,7 @@ func TestExecuteCommand(t *testing.T) {
 
 		require.Nil(t, appError)
 		assert.Equal(t, model.CommandResponseTypeEphemeral, commandResponse.ResponseType)
-		assert.Equal(t, "The channel export plugin requires a valid E20 license.", commandResponse.Text)
+		assert.Equal(t, "The channel export plugin requires a valid Enterprise license.", commandResponse.Text)
 	})
 
 	t.Run("missing e20 license with Testing and Developer modes enabled", func(t *testing.T) {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -43,7 +43,7 @@ const manifestStr = `
         "type": "bool",
         "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
         "placeholder": "",
-        "default": "false"
+        "default": false
       }
     ]
   }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -33,7 +33,7 @@ const manifest = JSON.parse(`
                 "type": "bool",
                 "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
                 "placeholder": "",
-                "default": "false"
+                "default": false
             }
         ]
     }


### PR DESCRIPTION
#### Summary
* #44 added a new config option but was not working because it was defined as string instead of bool. This has been updated in 7ea1180fef8a24d32907b5a6205e7d239321640c
* Improved error messages in  f38551b673a939ede49d21b375759b7ceb14adbf. In one case the channel ID was added to the `handleError` without it being specified resulting in `%!` character being shown in the error message

#### Ticket Link
N/A, it's part of a review

