### PR TITLE
[GH-51] Added conditional to disallow export in archived channel when it is not visible to users

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -143,7 +143,12 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if channel.DeleteAt > 0 && h.plugin.API.GetConfig().TeamSettings.ExperimentalViewArchivedChannels == nil {
+	areArchivedChannelsVisible := true
+	if h.plugin.API.GetConfig().TeamSettings.ExperimentalViewArchivedChannels == nil || !*h.plugin.API.GetConfig().TeamSettings.ExperimentalViewArchivedChannels {
+		areArchivedChannelsVisible = false
+	}
+
+	if channel.DeleteAt > 0 && !areArchivedChannelsVisible {
 		handleError(w, http.StatusNotFound, "channel '%s' is deleted and not visible anymore", channelID)
 		return
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -143,6 +143,11 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if channel.DeleteAt > 0 && h.plugin.API.GetConfig().TeamSettings.ExperimentalViewArchivedChannels == nil {
+		handleError(w, http.StatusNotFound, "channel '%s' is deleted and not visible anymore", channelID)
+		return
+	}
+
 	if !h.plugin.hasPermissionToExportChannel(userID, channelID) {
 		handleError(w, http.StatusForbidden, "user does not have permission to export channels")
 		return

--- a/server/api.go
+++ b/server/api.go
@@ -144,12 +144,12 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 	}
 
 	areArchivedChannelsVisible := true
-	if h.plugin.API.GetConfig().TeamSettings.ExperimentalViewArchivedChannels == nil || !*h.plugin.API.GetConfig().TeamSettings.ExperimentalViewArchivedChannels {
+	if h.client.Configuration.GetConfig().TeamSettings.ExperimentalViewArchivedChannels == nil || !*h.client.Configuration.GetConfig().TeamSettings.ExperimentalViewArchivedChannels {
 		areArchivedChannelsVisible = false
 	}
 
 	if channel.DeleteAt > 0 && !areArchivedChannelsVisible {
-		handleError(w, http.StatusNotFound, "channel '%s' is deleted and not visible anymore", channelID)
+		handleError(w, http.StatusNotFound, "channel '%s' is archived and not visible anymore", channelID)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
-  Added conditional to disallow export in archived channel when system setting “Allow users to view archived channels” is set to false

#### Screensots
![image](https://github.com/user-attachments/assets/929a8e43-483c-4afc-8f28-96844e1d07ab)

#### Steps to test:
1. Set system console setting “Allow users to view archived channels” is set to false
2. Hit this API from browser with the channel ID of a channel which is archived: http://localhost:8065/plugins/com.mattermost.plugin-channel-export/api/v1/export?channel_id=test-channel-id&format=csv

#### Ticket Link
Fixes #51 
