### PR TITLE
MM-60340  Enforce max file size when exporting to file via slash command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/mattermost/mattermost-server/v6 v6.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.9.0
 	github.com/wiggin77/merror v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -833,7 +833,6 @@ github.com/steveyen/gtreap v0.1.0/go.mod h1:kl/5J7XbrOmlIbYIXdRHDDE5QxHqpk0cmkT7
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -845,7 +844,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -1393,7 +1391,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -835,6 +835,10 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -843,6 +847,11 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
@@ -1386,6 +1395,8 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {

--- a/plugin.json
+++ b/plugin.json
@@ -28,8 +28,15 @@
                 "display_name": "Enable Admin Restrictions",
                 "type": "bool",
                 "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
-                "default": "false"
-            }
+                "default": false
+            },
+            {
+                "key": "MaxFileSize",
+                "display_name": "Maximum size of channel export file in bytes",
+                "type": "number",
+                "help_text": "Determines the maximum size of the channel export file when using the slash command. A value of 0 will use the [FileSettings.MaxFileSize](https://docs.mattermost.com/configure/environment-configuration-settings.html#maximum-file-size) from Mattermost server.",
+                "default": 0
+            }            
         ]
     }
 }

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -200,7 +200,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 
 			// Post the upload error only if the exporter did not do it before
 			var errLimitExceeded *util.ErrLimitExceeded
-			if !errors.Is(err, exportError) && !errors.As(err, errLimitExceeded) {
+			if !errors.Is(err, exportError) && !errors.As(err, &errLimitExceeded) {
 				err = p.client.Post.CreatePost(&model.Post{
 					UserId:    p.botID,
 					ChannelId: channelDM.Id,

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -199,7 +199,7 @@ func (p *Plugin) executeCommandExport(args *model.CommandArgs) *model.CommandRes
 			logger.WithError(err).Warn("failed to upload exported channel")
 
 			// Post the upload error only if the exporter did not do it before
-			var errLimitExceeded *util.ErrLimitExceeded
+			var errLimitExceeded util.ErrLimitExceeded
 			if !errors.Is(err, exportError) && !errors.As(err, &errLimitExceeded) {
 				err = p.client.Post.CreatePost(&model.Post{
 					UserId:    p.botID,

--- a/server/command_hooks_test.go
+++ b/server/command_hooks_test.go
@@ -423,4 +423,71 @@ func TestExecuteCommand(t *testing.T) {
 		// wait for upload to complete
 		wg.Wait()
 	})
+
+	var (
+		mockTypeString = gomock.AssignableToTypeOf("string")
+	)
+
+	t.Run("export file size exceeds max", func(t *testing.T) {
+		const maxFileSize = 50
+
+		mockCtrl := gomock.NewController(t)
+
+		mockChannel := mock_pluginapi.NewMockChannel(mockCtrl)
+		mockFile := mock_pluginapi.NewMockFile(mockCtrl)
+		mockLog := mock_pluginapi.NewMockLog(mockCtrl)
+		mockPost := mock_pluginapi.NewMockPost(mockCtrl)
+		mockSlashCommand := mock_pluginapi.NewMockSlashCommand(mockCtrl)
+		mockUser := mock_pluginapi.NewMockUser(mockCtrl)
+		mockSystem := mock_pluginapi.NewMockSystem(mockCtrl)
+		mockConfiguration := mock_pluginapi.NewMockConfiguration(mockCtrl)
+		mockCluster := mock_pluginapi.NewMockCluster(mockCtrl)
+		mockCluster.EXPECT().NewMutex(gomock.Eq(KeyClusterMutex)).Return(pluginapi.NewClusterMutexMock(), nil)
+
+		mockAPI := pluginapi.CustomWrapper(mockChannel, mockFile, mockLog, mockPost, mockSlashCommand, mockUser, mockSystem, mockConfiguration, mockCluster)
+
+		now := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.FixedZone("UTC-8", -8*60*60))
+		plugin, pluginContext := setupPlugin(t, mockAPI, now)
+
+		// set maximum file size
+		configuration := plugin.getConfiguration()
+		configuration.MaxFileSize = maxFileSize // bytes maximum
+		plugin.setConfiguration(configuration)
+
+		mockSystem.EXPECT().GetLicense().Return(&model.License{Features: &model.Features{
+			FutureFeatures: &trueValue,
+		}}).Times(2)
+		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
+		mockChannel.EXPECT().Get("channel_id").Return(&model.Channel{Id: "channel_id", Name: "channel_name"}, nil)
+		mockChannel.EXPECT().GetDirect("user_id", "bot_id").Return(&model.Channel{Id: "direct"}, nil)
+		mockUser.EXPECT().HasPermissionTo("user_id", model.PermissionManageSystem).Return(false).Times(1)
+		mockConfiguration.EXPECT().GetConfig().Return(&model.Config{}).Times(1)
+		mockLog.EXPECT().Error(mockTypeString, "Channel ID", mockTypeString, "Error", gomock.Any())
+
+		mockFile.EXPECT().Upload(gomock.Any(), "channel_name.csv", "direct").DoAndReturn(func(reader io.Reader, _, _ string) (*model.FileInfo, error) {
+			_, err := io.ReadAll(reader)
+			require.Error(t, err)
+			return nil, err
+		})
+
+		mockPost.EXPECT().CreatePost(&model.Post{
+			UserId:    "bot_id",
+			ChannelId: "direct",
+			Message:   "An error occurred uploading the exported channel ~channel_name.",
+		})
+
+		commandResponse, appError := plugin.ExecuteCommand(pluginContext, &model.CommandArgs{
+			Command:   "/export",
+			ChannelId: "channel_id",
+			UserId:    "user_id",
+		})
+
+		require.Nil(t, appError)
+		assert.Equal(t, model.CommandResponseTypeEphemeral, commandResponse.ResponseType)
+		assert.Equal(t, "Exporting ~channel_name. @channelexport will send you a direct message when the export is ready.", commandResponse.Text)
+
+		// Export runs asynchronuosly, so give time for that to occur and complete above
+		// mock assertions.
+		time.Sleep(1 * time.Second)
+	})
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -19,6 +19,7 @@ import (
 // copy appropriate for your types.
 type configuration struct {
 	EnableAdminRestrictions bool
+	MaxFileSize             uint64
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -81,4 +82,17 @@ func (p *Plugin) OnConfigurationChange() error {
 	p.setConfiguration(configuration)
 
 	return nil
+}
+
+// getMaxFileSize returns the maximum file size allowed when using the slash command.
+// If not set in plugin config, then the MM server FileUpload size is used instead.
+func (p *Plugin) getMaxFileSize() uint64 {
+	maxSize := p.getConfiguration().MaxFileSize
+	if maxSize == 0 {
+		mmconfig := p.API.GetConfig()
+		if mmconfig.FileSettings.MaxFileSize != nil {
+			maxSize = uint64(*mmconfig.FileSettings.MaxFileSize)
+		}
+	}
+	return maxSize
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -88,11 +88,16 @@ func (p *Plugin) OnConfigurationChange() error {
 // If not set in plugin config, then the MM server FileUpload size is used instead.
 func (p *Plugin) getMaxFileSize() uint64 {
 	maxSize := p.getConfiguration().MaxFileSize
-	if maxSize == 0 {
-		mmconfig := p.API.GetConfig()
+	if maxSize == 0 && p.API != nil {
+		mmconfig := p.client.Configuration.GetConfig()
 		if mmconfig.FileSettings.MaxFileSize != nil {
 			maxSize = uint64(*mmconfig.FileSettings.MaxFileSize)
 		}
 	}
+
+	if maxSize == 0 {
+		maxSize = 100 * 1024 * 1024 // 100MB (IEC)
+	}
+
 	return maxSize
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -43,7 +43,15 @@ const manifestStr = `
         "type": "bool",
         "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
         "placeholder": "",
-        "default": "false"
+        "default": false
+      },
+      {
+        "key": "MaxFileSize",
+        "display_name": "Maximum size of channel export file in bytes",
+        "type": "number",
+        "help_text": "Determines the maximum size of the channel export file when using the slash command. A value of 0 will use the [FileSettings.MaxFileSize](https://docs.mattermost.com/configure/environment-configuration-settings.html#maximum-file-size) from Mattermost server.",
+        "placeholder": "",
+        "default": 0
       }
     ]
   }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,7 +18,7 @@ const manifestStr = `
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "min_server_version": "5.37.0",
   "server": {
     "executables": {

--- a/server/util/limitpipewriter_test.go
+++ b/server/util/limitpipewriter_test.go
@@ -1,0 +1,142 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestLimitPipeWriter_WriteWithinLimit(t *testing.T) {
+	r, w := io.Pipe()
+	lpw := NewLimitPipeWriter(w, 10) // 10 bytes limit
+	data := []byte("hello")
+
+	go func() {
+		defer w.Close()
+		_, err := lpw.Write(data)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Errorf("unexpected error during io.Copy: %v", err)
+	}
+
+	if buf.String() != "hello" {
+		t.Errorf("expected 'hello', got %s", buf.String())
+	}
+}
+
+func TestLimitPipeWriter_WriteExceedsLimit(t *testing.T) {
+	r, w := io.Pipe()
+	lpw := NewLimitPipeWriter(w, 5) // 5 bytes limit
+	data := []byte("hello world")
+
+	go func() {
+		defer w.Close()
+		_, err := lpw.Write(data)
+		if err == nil {
+			t.Error("expected an error due to limit exceeded but got none")
+		} else if err.Error() != "limit (5 bytes) exceeded" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	}()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	// Expect an error due to exceeding limit
+	if err == nil {
+		t.Error("expected an error during io.Copy due to limit exceeded, but got none")
+	}
+
+	if buf.String() != "" {
+		t.Errorf("expected empty buffer due to limit exceeded, got %s", buf.String())
+	}
+}
+
+func TestLimitPipeWriter_MultipleWrites(t *testing.T) {
+	r, w := io.Pipe()
+	lpw := NewLimitPipeWriter(w, 10) // 10 bytes limit
+
+	go func() {
+		defer w.Close()
+		data1 := []byte("hello")
+		data2 := []byte("world")
+		_, err := lpw.Write(data1)
+		if err != nil {
+			t.Errorf("unexpected error writing first data block: %v", err)
+		}
+		_, err = lpw.Write(data2)
+		if err != nil {
+			t.Errorf("unexpected error writing second data block: %v", err)
+		}
+	}()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Errorf("unexpected error during io.Copy: %v", err)
+	}
+
+	if buf.String() != "helloworld" {
+		t.Errorf("expected 'helloworld', got %s", buf.String())
+	}
+}
+
+func TestLimitPipeWriter_WriteUpToLimit(t *testing.T) {
+	r, w := io.Pipe()
+	lpw := NewLimitPipeWriter(w, 5) // 5 bytes limit
+
+	go func() {
+		defer w.Close()
+		data := []byte("hello") // exactly 5 bytes
+		_, err := lpw.Write(data)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Errorf("unexpected error during io.Copy: %v", err)
+	}
+
+	if buf.String() != "hello" {
+		t.Errorf("expected 'hello', got %s", buf.String())
+	}
+}
+
+func TestLimitPipeWriter_CloseWithError(t *testing.T) {
+	r, w := io.Pipe()
+	lpw := NewLimitPipeWriter(w, 10)
+	expectedErr := fmt.Errorf("oh no!")
+
+	go func() {
+		data := []byte("hello")
+		_, err := lpw.Write(data)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		// Close the writer with an error
+		err = lpw.CloseWithError(expectedErr)
+		if err != nil {
+			t.Errorf("unexpected error closing pipe with error: %v", err)
+		}
+	}()
+
+	// Attempt to read, expecting a pipe error after first read
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err.Error() != expectedErr.Error() {
+		t.Errorf("expected error '%v', got '%v'", expectedErr, err)
+	}
+
+	if buf.String() != "hello" {
+		t.Errorf("expected 'hello', got '%s'", buf.String())
+	}
+}

--- a/server/util/limitpipewriter_test.go
+++ b/server/util/limitpipewriter_test.go
@@ -114,7 +114,7 @@ func TestLimitPipeWriter_WriteUpToLimit(t *testing.T) {
 func TestLimitPipeWriter_CloseWithError(t *testing.T) {
 	r, w := io.Pipe()
 	lpw := NewLimitPipeWriter(w, 10)
-	expectedErr := fmt.Errorf("oh no!")
+	expectedErr := fmt.Errorf("oh no")
 
 	go func() {
 		data := []byte("hello")

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -8,7 +8,7 @@ const manifest = JSON.parse(`
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -33,7 +33,15 @@ const manifest = JSON.parse(`
                 "type": "bool",
                 "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
                 "placeholder": "",
-                "default": "false"
+                "default": false
+            },
+            {
+                "key": "MaxFileSize",
+                "display_name": "Maximum size of channel export file in bytes",
+                "type": "number",
+                "help_text": "Determines the maximum size of the channel export file when using the slash command. A value of 0 will use the [FileSettings.MaxFileSize](https://docs.mattermost.com/configure/environment-configuration-settings.html#maximum-file-size) from Mattermost server.",
+                "placeholder": "",
+                "default": 0
             }
         ]
     }


### PR DESCRIPTION
#### Summary
Adds a plugin config for maximum file size which is enforced for slash commands which generate files.  If the config is not set, then the MM server file upload max size setting is used.

If a channel export exceeds the maximum file size, the file is not created and an error is DM'd to the user. e.g.:

```
An error occurred exporting channel [~Project Update](http://tower:8065/xanadu/channels/project-update): unable to write csv: limit (10000 bytes) exceeded
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60340