### PR TITLE
Bump version (remove rc)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
-    "version": "1.2.1-rc",
+    "version": "1.2.1",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,7 +18,7 @@ const manifestStr = `
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
-  "version": "1.2.1-rc",
+  "version": "1.2.1",
   "min_server_version": "5.37.0",
   "server": {
     "executables": {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -8,7 +8,7 @@ const manifest = JSON.parse(`
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
-    "version": "1.2.1-rc",
+    "version": "1.2.1",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Bumps version # by removing the `-rc`.  This will be the v1.2.1 release.

#### Ticket Link
NONE