### PR TITLE
Remove golang-version parameter from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,4 @@ jobs:
     uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
     with:
       golangci-lint-version: "v1.54.2"
-      golang-version: "1.21"
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove the `golang-version` input parameter from the CI workflow, as the `actions-workflows` `plugin-ci` reusable workflow no longer accepts this parameter.

## Test plan
- [ ] CI workflow runs successfully without the `golang-version` parameter